### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ This project is using Vite+, a unified toolchain built on top of Vite, Rolldown,
 
 Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.dev/guide/.
 
+## Built-in Commands vs Scripts
+
+`vp <name>` runs a built-in command. `vp run <name>` runs a `package.json` script or a `vite.config.ts` task. Scripts cannot overwrite built-ins, so `vp dev` and `vp run dev` may do different things. Check `package.json` and `vite.config.ts` first, and run `vp run <name>` when the project defines a script or task with that name.
+
 ## Review Checklist
 
 - [ ] Run `vp install` after pulling remote changes and before getting started.
@@ -14,3 +18,21 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - [ ] If setup, runtime, or package-manager behavior looks wrong, run `vp env doctor` and include its output when asking for help.
 
 <!--VITE PLUS END-->
+
+## Cursor Cloud specific instructions
+
+This repo is a single frontend app: `recipe-suggester` ("レシピGET!"), a React + TypeScript + Vite+ site that suggests a random recipe URL from `src/mapping.json`. There is no backend.
+
+### Toolchain / runtime
+
+- Node is managed by `nvm` with the default alias set to `24.19.0` (matches `.node-version`), and `npm` is pinned globally to `11.6.2` (matches the `devEngines` requirement and the devcontainer `Dockerfile`). The update script only runs `npm install` + a Playwright browser install; the node/npm versions come from this persisted nvm setup.
+- Gotcha: run commands in a login shell so `nvm` is sourced. A non-login shell may resolve `node` to `/exec-daemon/node` (v22) and mismatch the pinned `npm`, which triggers `npm error EBADDEVENGINES` on `npm install`. The Cursor terminal login shells already handle this.
+- `vp` is a project-local binary (`node_modules/.bin/vp`), not global here. Invoke it via the `package.json` scripts (`npm run dev`, `npm run check`, `npm run build`) or `npx vp`.
+
+### Run / lint / build / test
+
+- Dev server: `npm run dev` (runs `vp dev --host`) serves on `http://localhost:5173`.
+- Lint + typecheck + mapping validation: `npm run check` (`vp check` then `scripts/check-mapping.json.js`).
+- Build: `npm run build` (`tsc -b && vp build`).
+- E2E tests: `npx playwright test`. Playwright auto-starts the dev server via the `webServer` block in `playwright.config.ts`, so you do NOT need to start `npm run dev` first. Browsers `chromium` and `webkit` are required; the `webkit` clipboard test is intentionally skipped (WebKit lacks clipboard API support).
+- Git hooks: `vp config` (run by `npm` `prepare`) leaves `core.hooksPath` alone because Cursor already points it at its own agent hooks; this is expected, not an error.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `recipe-suggester` (the "レシピGET!" React + TypeScript + Vite+ app) so Cursor Cloud agents can lint, build, test, and run it.

The only code change is documentation: a `## Cursor Cloud specific instructions` section in `AGENTS.md` capturing durable, non-obvious setup gotchas (node/npm version management via `nvm`, the project-local `vp` binary, and how the Playwright e2e suite auto-starts the dev server).

Environment provisioning (Node 24.19.0 via `nvm`, npm pinned to 11.6.2, dependencies, and Playwright browsers + system deps) is handled by the environment update script and persisted state, not by source changes.

## Verification

All commands run in a login shell (so `nvm` provides Node 24.19.0 + npm 11.6.2):

| Step | Command | Result |
| --- | --- | --- |
| Install | `npm install` | success |
| Lint / typecheck / mapping | `npm run check` | pass (30 files formatted, 0 lint/type errors) |
| Build | `npm run build` | success (`dist/` produced) |
| E2E tests | `npx playwright test` | 11 passed, 1 skipped (webkit clipboard) |
| Dev server | `npm run dev` | serves `http://localhost:5173` (HTTP 200) |

### Hello-world task

Loaded the app in the browser and clicked the "レシピGETボタン" button, which is the app's core functionality. It rendered random recipe names on each click (e.g. "豚肉となすのコクうま炒め", "帆立の漬けどんぶり", "えのきの肉巻き").

[recipe_get_button_demo.mp4](https://cursor.com/agents/bc-07c8a58a-0b01-4e7f-9e34-fd795fbb8677/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frecipe_get_button_demo.mp4)

[Recipe displayed after clicking the button](https://cursor.com/agents/bc-07c8a58a-0b01-4e7f-9e34-fd795fbb8677/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frecipe_app_first_recipe.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07c8a58a-0b01-4e7f-9e34-fd795fbb8677?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07c8a58a-0b01-4e7f-9e34-fd795fbb8677&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

