### PR TITLE
Add Cursor Cloud Agent environment files

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,21 @@
+{
+  "name": "recipe-suggester",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "./node_modules/.bin/vp run dev",
+      "description": "Vite+ dev server for レシピGET! at http://localhost:5173"
+    }
+  ],
+  "ports": [
+    {
+      "name": "Vite+ dev server",
+      "port": 5173
+    },
+    {
+      "name": "Playwright HTML report",
+      "port": 9323
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Cloud Agent non-login shells may resolve `node` to /exec-daemon/node (v22).
+# Prefer the pinned Node from nvm when this snapshot has it.
+export NVM_DIR="${NVM_DIR:-${HOME}/.nvm}"
+if [[ -s "${NVM_DIR}/nvm.sh" ]]; then
+  # shellcheck disable=SC1091
+  . "${NVM_DIR}/nvm.sh"
+  NODE_VERSION="$(tr -d '[:space:]' < .node-version)"
+  nvm install "${NODE_VERSION}"
+  nvm use "${NODE_VERSION}"
+  export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PATH}"
+fi
+
+VP="node_modules/.bin/vp"
+if [[ ! -x "${VP}" ]]; then
+  corepack enable
+  corepack prepare pnpm@11.22.0 --activate
+  pnpm install
+fi
+
+"${VP}" install
+"${VP}" exec playwright install --with-deps chromium webkit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,9 @@ This repo is a single frontend app: `recipe-suggester` ("レシピGET!"), a Reac
 
 ### Toolchain / runtime
 
-- Node is managed by Vite Plus (matches `.node-version` `24.19.0`), and `pnpm` is pinned to `11.22.0` (matches the `devEngines` requirement). Use `vp install` / `vp add` / `vp remove` rather than calling pnpm directly; Vite+ downloads the pinned pnpm. The update script only runs `vp install` + a Playwright browser install.
-- Gotcha: run commands in a login shell so `nvm` is sourced. A non-login shell may resolve `node` to `/exec-daemon/node` (v22) instead of the pinned Node. The Cursor terminal login shells already handle this.
+- Node is managed by Vite Plus (matches `.node-version` `24.19.0`), and `pnpm` is pinned to `11.22.0` (matches the `devEngines` requirement). Use `vp install` / `vp add` / `vp remove` rather than calling pnpm directly; Vite+ downloads the pinned pnpm.
+- Cloud Agent bootstrap is defined in `.cursor/environment.json`. The `install` command runs `.cursor/install.sh` (`vp install` plus Playwright `chromium`/`webkit`).
+- Gotcha: run commands in a login shell so `nvm` is sourced. A non-login shell may resolve `node` to `/exec-daemon/node` (v22) instead of the pinned Node. The Cursor terminal login shells already handle this. The install script prepends nvm's Node onto `PATH` for the same reason.
 - `vp` is a project-local binary (`node_modules/.bin/vp`), not global here. Invoke it via `vp run <script>` (`vp run dev`, `vp run check`, `vp run build`) or `./node_modules/.bin/vp`. Do not use `npx` / `npm`; Vite+ does not translate mismatched package-manager commands.
 
 ### Run / lint / build / test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud Agents currently use a dashboard-managed personal environment. This adds a repository-managed config so setup follows the repo.

## Changes
- Add `.cursor/environment.json` with install, the Vite+ dev server terminal, and ports `5173` / `9323`
- Add `.cursor/install.sh` to run `vp install` and install Playwright `chromium` / `webkit`
- Point `AGENTS.md` Cloud Agent notes at these files

## Notes
Merging this makes `.cursor/environment.json` the highest-precedence environment source for agents started from this revision.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-542eeed8-e955-46d1-a929-9f8e8bb10c94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-542eeed8-e955-46d1-a929-9f8e8bb10c94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

